### PR TITLE
change {{body}} to {{{body}}} in "split into partials" step

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,10 @@ We are now going to create partials to simplify our website. Partials allow us t
 
 2. The next stage is to continue refactoring the layout in `main.hbs`. The goal is to have a layout that you can use for all pages on this site except error pages. **Tips**:
    * Use the [docs](http://handlebarsjs.com/) to find the syntax for inserting partials.
-   * Make sure you keep the `{{body}}`.
+   * Make sure you keep the 
+   ```hbs
+     {{{body}}}
+   ```
 
 ### Creating The Fruits Page
 


### PR DESCRIPTION
Apologies for the commit message, I initially pushed a commit which had prettier changes along with the actual edit i made, i reset the branch, deleted the remote and pushed again so that commit doesnt exist anymore.

basically the change is  on line 164, {{body}} should be {{{body}}} with a triple bracket, because this is where the layouts will be plugged in, and needs to be an unescaped handlebars expression.
earlier in the workshop the students are told to write {{{body}}}, and the solution also has {{{body}}}

I remember for fac17 this was confusing, and led to us being uncertainty over the difference between {{}} and {{{}}}
